### PR TITLE
feat: add 'check' column to SensorHistory model

### DIFF
--- a/alembic/versions/c991d80742c7_add_model_sensorhistory.py
+++ b/alembic/versions/c991d80742c7_add_model_sensorhistory.py
@@ -83,6 +83,7 @@ def upgrade() -> None:
                         'CURRENT_TIMESTAMP'), nullable=True),
                     sa.Column('updated_at', sa.DateTime(), server_default=sa.text(
                         'CURRENT_TIMESTAMP'), nullable=True),
+                    sa.Column('check', sa.Boolean(), nullable=True, server_default=sa.text('false')),
                     sa.PrimaryKeyConstraint('id'),
                     sa.UniqueConstraint('deduplication_id')
                     )

--- a/src/api/v1/endpoints/sensors.py
+++ b/src/api/v1/endpoints/sensors.py
@@ -108,7 +108,10 @@ def get_sensor_history(
     api_key: str = Depends(get_api_key)
 ):
 
-    query = select(SensorHistory).where(SensorHistory.dev_eui == dev_eui)
+    query = select(SensorHistory).where(
+        SensorHistory.dev_eui == dev_eui,
+        (SensorHistory.check == None) | (SensorHistory.check == False)  
+    )
 
     if start_date:
         query = query.where(SensorHistory.time >= start_date)

--- a/src/api/v1/endpoints/sensors.py
+++ b/src/api/v1/endpoints/sensors.py
@@ -129,3 +129,19 @@ def get_sensor_history(
         )
 
     return results
+
+@router.post("/updateSensorHistory")
+def update_sensor_history(
+    ids: List[int],
+    session: Session = Depends(get_session),
+    api_key: str = Depends(get_api_key)
+):
+    records = session.exec(
+        select(SensorHistory).where(SensorHistory.id.in_(ids))
+    ).all()
+    if not records:
+        raise HTTPException(status_code=404, detail="No records found with provided IDs")
+    for record in records:
+        record.check = True
+    session.commit()
+    

--- a/src/api/v1/endpoints/sensors.py
+++ b/src/api/v1/endpoints/sensors.py
@@ -110,7 +110,7 @@ def get_sensor_history(
 
     query = select(SensorHistory).where(
         SensorHistory.dev_eui == dev_eui,
-        (SensorHistory.check == None) | (SensorHistory.check == False)  
+        (SensorHistory.check == None) | (SensorHistory.check == False)
     )
 
     if start_date:
@@ -133,6 +133,7 @@ def get_sensor_history(
 
     return results
 
+
 @router.post("/updateSensorHistory")
 def update_sensor_history(
     ids: List[int],
@@ -143,8 +144,10 @@ def update_sensor_history(
         select(SensorHistory).where(SensorHistory.id.in_(ids))
     ).all()
     if not records:
-        raise HTTPException(status_code=404, detail="No records found with provided IDs")
+        raise HTTPException(
+            status_code=404, detail="No records found with provided IDs")
     for record in records:
         record.check = True
     session.commit()
-    
+
+    return {"updated": len(records), "ids": [record.id for record in records]}


### PR DESCRIPTION
This pull request includes changes to add a new column to the `SensorHistory` model and introduces a new endpoint to update sensor history records. The most important changes are listed below:

Database schema changes:
* [`alembic/versions/c991d80742c7_add_model_sensorhistory.py`](diffhunk://#diff-b6a43f81645aa642429376e917827ad4467690590fd1665c0d63c1afc60c078fR86): Added a new column `check` of type `Boolean` with a default value of `false` to the `SensorHistory` table.

API endpoint additions:
* [`src/api/v1/endpoints/sensors.py`](diffhunk://#diff-a831e1913c5a6951e195ec6d9ad2e67f596585208c727a673ad2845281bbaddbR132-R147): Added a new endpoint `updateSensorHistory` to update the `check` field of `SensorHistory` records based on provided IDs.